### PR TITLE
Support direct write to /sys/class/backlight for where logind support is unavailable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,32 @@
+name: Rust Build
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+  IMAGE_NAME: brightness
+
+jobs:
+
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cargo Test
+        run: cargo test
+
+
+  check_style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cargo Format Check
+        run: cargo fmt -- --check
+
+      - name: Cargo Sort Check
+        run: cargo install cargo-sort && cargo-sort --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,7 @@ async-trait = "0.1.50"
 either = "1.6.1"
 futures = "0.3.16"
 thiserror = "1.0.26"
-zbus = "1.9.1"
+zbus = { version = "1.9.1", optional = true }
+
+[features]
+default = ["zbus"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 <!-- cargo-sync-readme start -->
 
-# Overview
-- [📦 crates.io](https://crates.io/crates/brightness)
-- [📖 Documentation](https://docs.rs/brightness)
-- [⚖ 0BSD license](https://spdx.org/licenses/0BSD.html)
+[![Build status](https://github.com/stephaneyfx/brightness/actions/workflows/rust.yml/badge.svg)](https://github.com/stephaneyfx/brightness/actions)
+[![crates.io](https://img.shields.io/crates/v/brightness.svg)](https://crates.io/crates/brightness)
+[![docs.rs](https://docs.rs/brightness/badge.svg)](https://docs.rs/brightness)
 
-Definitions to get and set brightness on Linux. This relies on D-Bus and logind.
+# Overview
+
+[⚖ 0BSD license](https://spdx.org/licenses/0BSD.html)
 
 # Example
 
@@ -22,6 +23,20 @@ async fn show_brightness() -> Result<(), brightness::Error> {
     }).await
 }
 ```
+
+## Linux
+
+This library interacts with the displays found at `/sys/class/backlight`. Note this means that in order to control 
+external displays (via the DDC/CI) protocol, you need to have the 
+[ddcci-backlight](https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux#ddcci-backlight-monitor-backlight-driver)
+kernel driver loaded first.
+
+When the `zbus` cargo feature is enabled the library will try to use `D-Bus` to write the backlight values via 
+`systemd-logind`, however this requires 
+[systemd 243 or later](https://github.com/systemd/systemd/blob/877aa0bdcc2900712b02dac90856f181b93c4e40/NEWS#L262).
+You can disable this with the `--no-default-features` flag, and the library will instead write directly to 
+`/sys/class/backlight/$DEVICE/brightness` - however this requires you to set the permissions on these paths 
+appropriately for non-root users (look at using `udev` rules).
 
 # Contribute
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,3 +105,16 @@ pub enum Error {
         source: Box<dyn StdError + Send + Sync>,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::brightness_devices;
+    use futures::executor::block_on_stream;
+
+    #[test]
+    fn it_works() {
+        for i in block_on_stream(brightness_devices()) {
+            println!("{:?}", i);
+        }
+    }
+}


### PR DESCRIPTION
First of all thanks for this awesome library - I have been thinking about writing something like this for the last year!

I am having difficulty in that the distro I am using (Oracle Linux 8.4) does not yet support the SetBrightness function in logind:

```
$ dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1/session/7 org.freedesktop.login1.Session.SetBrightness
Error org.freedesktop.DBus.Error.UnknownMethod: Unknown method 'SetBrightness' or interface 'org.freedesktop.login1.Session'.
```

I believe it was only added in systemd 243 and I am on systemd 239. It doesn't look like it is easy to update myself (there isn't a newer package available) - and I'm guessing this is currently the same for all RHEL/CentOS/Oracle distros.

What the PR does is add `zbus` as a default feature, but when the feature is disabled it will instead fallback to writing directly to `/sys/class/backlight/$DEVICE/brightness`

I have also added a Github action to build and style check, and updated the README with some info about this.

