### PR TITLE
Filter inactive monitors (Windows)

### DIFF
--- a/brightness-windows/build.rs
+++ b/brightness-windows/build.rs
@@ -17,7 +17,7 @@ fn generate_windows_bindings() {
         Windows::Win32::Foundation::{CloseHandle, BOOL, HANDLE, LPARAM, PWSTR, RECT},
         Windows::Win32::Graphics::Gdi::{
             EnumDisplayDevicesW, EnumDisplayMonitors, GetMonitorInfoW, DISPLAY_DEVICEW, HDC,
-            HMONITOR, MONITORINFO, MONITORINFOEXW,
+            HMONITOR, MONITORINFO, MONITORINFOEXW, DISPLAY_DEVICE_ACTIVE
         },
         Windows::Win32::Storage::FileSystem::{
             CreateFileW, FILE_ACCESS_FLAGS, FILE_FLAGS_AND_ATTRIBUTES,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -12,8 +12,8 @@ use brightness_windows::Windows::Win32::{
     },
     Foundation::{CloseHandle, BOOL, HANDLE, LPARAM, PWSTR, RECT},
     Graphics::Gdi::{
-        EnumDisplayDevicesW, EnumDisplayMonitors, GetMonitorInfoW, DISPLAY_DEVICEW, HDC, HMONITOR,
-        MONITORINFO, MONITORINFOEXW,
+        EnumDisplayDevicesW, EnumDisplayMonitors, GetMonitorInfoW, DISPLAY_DEVICEW,
+        DISPLAY_DEVICE_ACTIVE, HDC, HMONITOR, MONITORINFO, MONITORINFOEXW,
     },
     Storage::FileSystem::{
         CreateFileW, FILE_ACCESS_FLAGS, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_READ,
@@ -208,6 +208,11 @@ pub fn brightness_devices() -> impl Stream<Item = Result<Brightness, SysError>> 
                         })
                         .take_while(Option::is_some)
                         .flatten()
+                        .filter(|device| {
+                            // Filter out inactive displays since they won't have a corresponding
+                            // physical monitor
+                            (device.StateFlags & DISPLAY_DEVICE_ACTIVE) == DISPLAY_DEVICE_ACTIVE
+                        })
                         .collect::<Vec<_>>();
                     if display_devices.len() != physical_monitors.len() {
                         // There doesn't seem to be any way to directly associate a physical monitor


### PR DESCRIPTION
Fixes an [EnumerationMismatch error](
https://github.com/stephaneyfx/brightness/issues/4) on Windows that occurs when having a display physically connected but not enabled.
