### PR TITLE
Add friendly device name to Brightness API

### DIFF
--- a/examples/list_displays_async.rs
+++ b/examples/list_displays_async.rs
@@ -18,6 +18,7 @@ async fn run() {
 
 async fn show_brightness(dev: &BrightnessDevice) -> Result<(), brightness::Error> {
     println!("Display {}", dev.device_name().await?);
+    println!("\tFriendly name = {}", dev.friendly_device_name().await?);
     println!("\tBrightness = {}%", dev.get().await?);
     show_platform_specific_info(dev).await?;
     Ok(())

--- a/examples/set_brightness_async.rs
+++ b/examples/set_brightness_async.rs
@@ -24,7 +24,7 @@ async fn run(percentage: u32) {
 async fn show_brightness(dev: &BrightnessDevice) -> Result<(), brightness::Error> {
     println!(
         "Brightness of device {} is {}%",
-        dev.device_name().await?,
+        dev.friendly_device_name().await?,
         dev.get().await?
     );
     Ok(())

--- a/examples/set_brightness_blocking.rs
+++ b/examples/set_brightness_blocking.rs
@@ -23,7 +23,7 @@ fn run(percentage: u32) {
 fn show_brightness(dev: &BrightnessDevice) -> Result<(), brightness::Error> {
     println!(
         "Brightness of device {} is {}%",
-        dev.device_name()?,
+        dev.friendly_device_name()?,
         dev.get()?
     );
     Ok(())

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -25,6 +25,9 @@ pub trait Brightness {
     /// Returns the device name.
     fn device_name(&self) -> Result<String, Error>;
 
+    /// Returns the user friendly device name.
+    fn friendly_device_name(&self) -> Result<String, Error>;
+
     /// Returns the current brightness as a percentage.
     fn get(&self) -> Result<u32, Error>;
 
@@ -35,6 +38,10 @@ pub trait Brightness {
 impl Brightness for BrightnessDevice {
     fn device_name(&self) -> Result<String, Error> {
         self.0.device_name()
+    }
+
+    fn friendly_device_name(&self) -> Result<String, Error> {
+        self.0.friendly_device_name()
     }
 
     fn get(&self) -> Result<u32, Error> {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -25,7 +25,8 @@ pub trait Brightness {
     /// Returns the device name.
     fn device_name(&self) -> Result<String, Error>;
 
-    /// Returns the user friendly device name.
+    /// Returns a human-readable device name suitable for display to users.
+    /// This may differ from the technical device identifier returned by `device_name()`.
     fn friendly_device_name(&self) -> Result<String, Error>;
 
     /// Returns the current brightness as a percentage.

--- a/src/blocking/linux.rs
+++ b/src/blocking/linux.rs
@@ -22,6 +22,10 @@ impl crate::blocking::Brightness for BlockingDeviceImpl {
         Ok(self.device.clone())
     }
 
+    fn friendly_device_name(&self) -> Result<String, Error> {
+        Ok(self.device.clone())
+    }
+
     fn get(&self) -> Result<u32, Error> {
         let max = read_value(&self.device, Value::Max)?;
         let actual = read_value(&self.device, Value::Actual)?;

--- a/src/blocking/windows.rs
+++ b/src/blocking/windows.rs
@@ -59,6 +59,7 @@ pub(crate) struct BlockingDeviceImpl {
     physical_monitor: WrappedPhysicalMonitor,
     file_handle: WrappedFileHandle,
     device_name: String,
+    friendly_name: String,
     /// Note: PHYSICAL_MONITOR.szPhysicalMonitorDescription == DISPLAY_DEVICEW.DeviceString
     /// Description is **not** unique.
     pub(crate) device_description: String,
@@ -125,6 +126,10 @@ fn flag_set<T: std::ops::BitAnd<Output = T> + std::cmp::PartialEq + Copy>(t: T, 
 impl crate::blocking::Brightness for BlockingDeviceImpl {
     fn device_name(&self) -> Result<String, Error> {
         Ok(self.device_name.clone())
+    }
+
+    fn friendly_device_name(&self) -> Result<String, Error> {
+        Ok(self.friendly_name.clone())
     }
 
     fn get(&self) -> Result<u32, Error> {
@@ -194,6 +199,7 @@ pub(crate) fn brightness_devices() -> impl Iterator<Item = Result<BlockingDevice
                                 physical_monitor,
                                 file_handle,
                                 device_name: wchar_to_string(&display_device.DeviceName),
+                                friendly_name: wchar_to_string(&info.monitorFriendlyDeviceName),
                                 device_description: wchar_to_string(&display_device.DeviceString),
                                 device_key: wchar_to_string(&display_device.DeviceKey),
                                 device_path: wchar_to_string(&display_device.DeviceID),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,9 @@ mod r#async {
         /// Returns the device name.
         fn device_name(&self) -> impl Future<Output = Result<String, Error>> + Send;
 
+        /// Returns the user friendly device name.
+        fn friendly_device_name(&self) -> impl Future<Output = Result<String, Error>> + Send;
+
         /// Returns the current brightness as a percentage.
         fn get(&self) -> impl Future<Output = Result<u32, Error>> + Send;
 
@@ -93,6 +96,10 @@ mod r#async {
     impl Brightness for BrightnessDevice {
         async fn device_name(&self) -> Result<String, Error> {
             self.0.device_name().await
+        }
+
+        async fn friendly_device_name(&self) -> Result<String, Error> {
+            self.0.friendly_device_name().await
         }
 
         async fn get(&self) -> Result<u32, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,8 @@ mod r#async {
         /// Returns the device name.
         fn device_name(&self) -> impl Future<Output = Result<String, Error>> + Send;
 
-        /// Returns the user friendly device name.
+        /// Returns a human-readable device name suitable for display to users,
+        /// which may differ from the technical device identifier returned by `device_name`.
         fn friendly_device_name(&self) -> impl Future<Output = Result<String, Error>> + Send;
 
         /// Returns the current brightness as a percentage.

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -22,6 +22,10 @@ impl crate::Brightness for AsyncDeviceImpl {
         Ok(self.device.clone())
     }
 
+    async fn friendly_device_name(&self) -> Result<String, Error> {
+        Ok(self.device.clone())
+    }
+
     async fn get(&self) -> Result<u32, Error> {
         let max = read_value(&self.device, Value::Max)?;
         let actual = read_value(&self.device, Value::Actual)?;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -25,6 +25,10 @@ impl crate::Brightness for AsyncDeviceImpl {
         self.0.device_name()
     }
 
+    async fn friendly_device_name(&self) -> Result<String, Error> {
+        self.0.friendly_device_name()
+    }
+
     async fn get(&self) -> Result<u32, Error> {
         let cloned = Arc::clone(&self.0);
         unblock(move || cloned.get()).await


### PR DESCRIPTION
Introduces a `friendly_device_name` method to both async and blocking Brightness traits and implementations for Linux and Windows (On Linux, right now it just falls back to `device_name`). Example code updated to display the friendly device name instead of the technical device name, improving user-facing output.

This addresses #12 